### PR TITLE
Python Example update

### DIFF
--- a/websockets/python/polygon.py
+++ b/websockets/python/polygon.py
@@ -1,3 +1,5 @@
+# Be sure to pip install polygon-api-client
+
 import time
 
 from polygon import WebSocketClient, STOCKS_CLUSTER

--- a/websockets/python/polygon.py
+++ b/websockets/python/polygon.py
@@ -1,27 +1,30 @@
-# Be sure to pip install websocket-client
-# Details: https://pypi.org/project/websocket-client/
+import time
 
-import websocket
+from polygon import WebSocketClient, STOCKS_CLUSTER
 
-def on_message(ws, message):
-	print(message)
 
-def on_error(ws, error):
-	print(error)
+def my_custom_process_message(message):
+    print("this is my custom message processing", message)
 
-def on_close(ws):
-	print("### closed ###")
 
-def on_open(ws):
-	ws.send('{"action":"auth","params":"YOUR_API_KEY"}')
-	ws.send('{"action":"subscribe","params":"C.AUD/USD,C.USD/EUR,C.USD/JPY"}')
+def my_custom_error_handler(ws, error):
+    print("this is my custom error handler", error)
+
+
+def my_custom_close_handler(ws):
+    print("this is my custom close handler")
+
+
+def main():
+    key = 'your api key'
+    my_client = WebSocketClient(STOCKS_CLUSTER, key, my_custom_process_message)
+    my_client.run_async()
+
+    my_client.subscribe("T.MSFT", "T.AAPL", "T.AMD", "T.NVDA")
+    time.sleep(1)
+
+    my_client.close_connection()
+
 
 if __name__ == "__main__":
-	# websocket.enableTrace(True)
-	ws = websocket.WebSocketApp("wss://socket.polygon.io/forex",
-							  on_message = on_message,
-							  on_error = on_error,
-							  on_close = on_close)
-	ws.on_open = on_open
-	ws.run_forever()
-
+    main()


### PR DESCRIPTION
The maintained python demo example is located in the [here](https://github.com/polygon-io/client-python/blob/master/websocket-example.py) in the client-python repo. This PR brings this example in line with that file. This is a temporary fix needed for the link that is used on the WS docs. We'll eventually move all examples in this repo to the appropriate client-* repo and update the reference links on the WS docs at that time.  